### PR TITLE
Enable buildConfig in app/build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,7 @@ android {
     buildFeatures {
         dataBinding true
         compose true
+        buildConfig true
     }
     composeOptions {
         kotlinCompilerExtensionVersion '1.1.1'


### PR DESCRIPTION
This change enables the buildConfig feature in the app/build.gradle file, allowing you to access build-time configurations in your code.